### PR TITLE
Fixes the segfaults in OccurenceCollector and improves debuggability

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -57,6 +57,6 @@ if [[ $WIN != "1" ]]; then
     pip install src/server/tests tests/server
     # NOTE: `--full-trace` tends to print excessively long stack traces. Please
     # re-enable it if needed:
-    # pytest -vv --showlocals --full-trace --capture=no --timeout=5 tests/server
-    pytest -vv --showlocals --capture=no --timeout=5 tests/server
+    # pytest -vv --showlocals --full-trace --capture=no --timeout=10 tests/server
+    pytest -vv --showlocals --timeout=10 tests/server
 fi

--- a/src/bin/lfortran_lsp_language_server.cpp
+++ b/src/bin/lfortran_lsp_language_server.cpp
@@ -194,8 +194,10 @@ namespace LCompilers::LanguageServerProtocol {
                 logger.trace()
                     << "Getting diagnostics from LFortran for document with URI="
                     << uri << std::endl;
+                std::unique_lock<std::recursive_mutex> loggerLock(logger.mutex());
                 std::vector<lc::error_highlight> highlights =
                     lfortran.showErrors(path, text, *compilerOptions);
+                loggerLock.unlock();
 
                 logger.trace()
                     << "Collected " << highlights.size()
@@ -397,8 +399,10 @@ namespace LCompilers::LanguageServerProtocol {
             << " on line=" << compilerOptions.line
             << ", column=" << compilerOptions.column
             << std::endl;
+        std::unique_lock<std::recursive_mutex> loggerLock(logger.mutex());
         std::vector<lc::document_symbols> symbols =
             lfortran.lookupName(path, text, compilerOptions);
+        loggerLock.unlock();
         logger.trace()
             << "Found " << symbols.size() << " symbol(s) matching the query."
             << std::endl;
@@ -481,8 +485,10 @@ namespace LCompilers::LanguageServerProtocol {
             << " on line=" << compilerOptions.line
             << ", column=" << compilerOptions.column
             << std::endl;
+        std::unique_lock<std::recursive_mutex> loggerLock(logger.mutex());
         std::vector<lc::document_symbols> symbols =
             lfortran.getAllOccurrences(path, text, compilerOptions);
+        loggerLock.unlock();
         logger.trace()
             << "Found " << symbols.size() << " symbol(s) matching the query."
             << std::endl;
@@ -540,8 +546,10 @@ namespace LCompilers::LanguageServerProtocol {
         logger.trace()
             << "Looking up all symbols in document with URI=" << uri
             << std::endl;
+        std::unique_lock<std::recursive_mutex> loggerLock(logger.mutex());
         std::vector<lc::document_symbols> symbols =
             lfortran.getSymbols(path, text, *compilerOptions);
+        loggerLock.unlock();
         logger.trace()
             << "Found " << symbols.size() << " symbol(s) matching the query."
             << std::endl;
@@ -639,8 +647,10 @@ namespace LCompilers::LanguageServerProtocol {
             << " on line=" << compilerOptions.line
             << ", column=" << compilerOptions.column
             << std::endl;
+        std::unique_lock<std::recursive_mutex> loggerLock(logger.mutex());
         std::vector<lc::document_symbols> symbols =
             lfortran.lookupName(path, text, compilerOptions);
+        loggerLock.unlock();
         logger.trace()
             << "Found " << symbols.size() << " symbol(s) matching the query."
             << std::endl;
@@ -675,6 +685,7 @@ namespace LCompilers::LanguageServerProtocol {
             logger.trace()
                 << "Formatting hover preview with LFortran"
                 << std::endl;
+            std::unique_lock<std::recursive_mutex> loggerLock(logger.mutex());
             lc::Result<std::string> formatted = lfortran.format(
                 path,
                 preview,
@@ -683,6 +694,7 @@ namespace LCompilers::LanguageServerProtocol {
                 config->indentSize,
                 true  //<- indent units like module bodies
             );
+            loggerLock.unlock();
             if (formatted.ok) {
                 logger.trace() << "Successfully formatted the preview." << std::endl;
                 content.value.append(formatted.result);
@@ -798,8 +810,10 @@ namespace LCompilers::LanguageServerProtocol {
         logger.trace()
             << "Finding all occurrences of symbol to highlight in document with URI="
             << uri << std::endl;
+        std::unique_lock<std::recursive_mutex> loggerLock(logger.mutex());
         std::vector<lc::document_symbols> symbols =
             lfortran.getAllOccurrences(path, text, compilerOptions);
+        loggerLock.unlock();
         logger.trace()
             << "Found " << symbols.size() << " symbol(s) matching the query."
             << std::endl;

--- a/src/lfortran/parser/semantics.h
+++ b/src/lfortran/parser/semantics.h
@@ -1703,7 +1703,7 @@ return make_Program_t(al, a_loc,
         /*contains*/ CONTAINS(contains), \
         /*n_contains*/ contains.size(), \
         /*start_name*/ &(name->loc), \
-        /*end_name*/ &(name_opt->loc))
+        /*end_name*/ (name_opt) ? &((name_opt)->loc) : nullptr)
 #define RESULT(x) p.result.push_back(p.m_a, x)
 
 #define STMT_NAME(id_first, id_last, stmt) \

--- a/src/server/tests/setup.cfg
+++ b/src/server/tests/setup.cfg
@@ -28,6 +28,7 @@ install_requires =
     attrs==24.3.0
     cattrs==24.1.2
     lsprotocol==2023.0.1
+    psutil==7.0.0
 
 [options.packages.find]
 where = src

--- a/src/server/tests/src/llanguage_test_client/lsp_json_stream.py
+++ b/src/server/tests/src/llanguage_test_client/lsp_json_stream.py
@@ -2,7 +2,7 @@ import io
 import json
 import time
 from io import BytesIO
-from typing import IO, Optional, Union
+from typing import Callable, IO, Optional, Union
 
 from llanguage_test_client.json_rpc import JsonArray, JsonObject
 
@@ -15,29 +15,45 @@ class LspJsonStream:
     istream: IO[bytes]
     timeout_s: float
 
-    buf: BytesIO
+    bs: Optional[bytes]
+    bi: int
+    message_buf: BytesIO
     num_bytes: int
     has_content_length: bool
     position: int
     sleep_s: float = 0.100
+    check_server: Callable[[], bool]
 
-    def __init__(self, istream: IO[bytes], timeout_s: float) -> None:
+    def __init__(self, istream: IO[bytes], timeout_s: float, check_server: Callable[[], bool]) -> None:
         self.istream = istream
         self.timeout_s = timeout_s
-        self.buf = BytesIO()
+        self.bs = None
+        self.bi = 0
+        self.message_buf = BytesIO()
+        self.check_server = check_server
 
     def message(self) -> str:
-        return self.buf.getvalue().decode("utf-8")
+        return self.message_buf.getvalue().decode("utf-8")
 
     def next_byte(self) -> bytes:
         start_time = time.perf_counter()
-        while duration(start_time) < self.timeout_s:
+        bi = self.bi
+        bs = self.bs
+        if (bs is not None) and (bi < len(bs)):
+            bj = bi + 1
+            b = bs[bi:bj]
+            self.bi = bj
+            self.message_buf.write(b)
+            self.position += 1
+            return b
+        while self.check_server() \
+              and ((duration(start_time) < self.timeout_s)
+                   or (self.timeout_s == 0.0)):
             try:
-                bs: Optional[bytes] = self.istream.read(1)
-                if bs is not None and len(bs) > 0:
-                    self.buf.write(bs)
-                    self.position += 1
-                    return bs
+                self.bs = self.istream.read(4096)
+                if (self.bs is not None) and (len(self.bs) > 0):
+                    self.bi = 0
+                    return self.next_byte()
             except BlockingIOError:
                 # Try again ...
                 pass
@@ -49,8 +65,8 @@ class LspJsonStream:
     def next(self) -> Union[JsonObject, JsonArray]:
         self.num_bytes = 0
         self.position = 0
-        self.buf.seek(0)
-        self.buf.truncate(0)
+        self.message_buf.seek(0)
+        self.message_buf.truncate(0)
         return self.parse_header_name()
 
     def escape(self, bs: bytes) -> bytes:
@@ -90,9 +106,9 @@ class LspJsonStream:
                     )
                 case b':':
                     length: int = self.position - start - 1
-                    self.buf.seek(start)
-                    header_name: str = self.buf.read(length).upper().decode("utf-8")
-                    self.buf.seek(0, io.SEEK_END)
+                    self.message_buf.seek(start)
+                    header_name: str = self.message_buf.read(length).upper().decode("utf-8")
+                    self.message_buf.seek(0, io.SEEK_END)
                     self.has_content_length = (header_name == "CONTENT-LENGTH")
                     return self.parse_header_value()
                 case _:
@@ -113,9 +129,9 @@ class LspJsonStream:
                             f"Expected \\r to be followed by \\n, not '{self.escape(b)}':\n{self.message()}"
                         )
                     if self.has_content_length:
-                        self.buf.seek(start)
-                        header_value: str = self.buf.read(length).decode("utf-8")
-                        self.buf.seek(0, io.SEEK_END)
+                        self.message_buf.seek(start)
+                        header_value: str = self.message_buf.read(length).decode("utf-8")
+                        self.message_buf.seek(0, io.SEEK_END)
                         self.num_bytes = int(header_value)
                     return self.parse_header_name()
                 case b'\n':
@@ -127,12 +143,23 @@ class LspJsonStream:
 
     def parse_body(self) -> Union[JsonObject, JsonArray]:
         remaining_bytes = self.num_bytes
+        bs = self.bs
+        bi = self.bi
+        if (bs is not None) and (bi < len(bs)):
+            bk = len(bs) - bi
+            bj = bi + min(bk, remaining_bytes)
+            self.message_buf.write(bs[bi:bj])
+            remaining_bytes -= bk
+            self.bi = bj
         start_time = time.perf_counter()
-        while (remaining_bytes > 0) and (duration(start_time) < self.timeout_s):
+        while (remaining_bytes > 0) \
+              and self.check_server() \
+              and ((duration(start_time) < self.timeout_s)
+                   or (self.timeout_s == 0.0)):
             try:
                 bs = self.istream.read(remaining_bytes)
                 if bs is not None and len(bs) > 0:
-                    self.buf.write(bs)
+                    self.message_buf.write(bs)
                     remaining_bytes -= len(bs)
                     continue
             except BlockingIOError:
@@ -142,7 +169,7 @@ class LspJsonStream:
             raise RuntimeError(
                 f'Timed-out after {self.timeout_s} seconds while reading from the stream:\n{self.message()}'
             )
-        self.buf.seek(self.buf.tell() - self.num_bytes)
-        body: str = self.buf.read().decode("utf-8")
-        self.buf.seek(0, io.SEEK_END)
+        self.message_buf.seek(self.message_buf.tell() - self.num_bytes)
+        body: str = self.message_buf.read().decode("utf-8")
+        self.message_buf.seek(0, io.SEEK_END)
         return json.loads(body)

--- a/src/server/tests/src/llanguage_test_client/lsp_test_client.py
+++ b/src/server/tests/src/llanguage_test_client/lsp_test_client.py
@@ -15,6 +15,8 @@ from pathlib import Path
 from typing import (IO, Any, BinaryIO, Callable, Dict, Iterator, List,
                     Optional, Set, Tuple, Union)
 
+import psutil
+
 from cattrs import Converter
 
 from lsprotocol import converters
@@ -184,6 +186,7 @@ class LspTestClient(LspClient):
     timeout_s: float
 
     server: ServerProcess
+    process: psutil.Process
     message_stream: LspJsonStream
     ostream: IO[bytes]
     buf: BytesIO
@@ -202,7 +205,7 @@ class LspTestClient(LspClient):
     responses_by_id: Dict[JsonValue, Any]
     callbacks_by_id: Dict[JsonValue, Tuple[Any, Callback]]
     stop: threading.Event
-    # stderr_printer: threading.Thread
+    stderr_printer: threading.Thread
     client_log_path: str
     stdout_log_path: str
     stdin_log_path: str
@@ -236,27 +239,32 @@ class LspTestClient(LspClient):
         self.responses_by_id = dict()
         self.callbacks_by_id = dict()
         self.stop = threading.Event()
-        # self.stderr_printer = threading.Thread(
-        #     target=self.print_stderr,
-        #     args=tuple()
-        # )
+        self.stderr_printer = threading.Thread(
+            target=self.print_stderr,
+            args=tuple()
+        )
         self.client_log_path = client_log_path
         self.stdout_log_path = stdout_log_path
         self.stdin_log_path = stdin_log_path
 
     def print_stderr(self) -> None:
         if self.server.stderr is not None:
-            buf = StringIO()
+            buf = BytesIO()
             while self.check_server() and not self.stop.is_set():
                 try:
-                    bs = self.server.stderr.read(1)
+                    bs = self.server.stderr.read(4096)
                     if bs is not None:
                         buf.seek(0)
                         buf.truncate(0)
-                        while (bs is not None) and (len(bs) > 0) and not self.stop.is_set():
-                            buf.write(bs.decode("utf-8"))
-                            bs = self.server.stderr.read(1)
-                        print(buf.getvalue(), file=sys.stderr)
+                        while (bs is not None) \
+                              and (len(bs) > 0) \
+                              and not self.stop.is_set():
+                            buf.write(bs)
+                            if self.check_server():
+                                bs = self.server.stderr.read(4096)
+                            else:
+                                break
+                        print(buf.getvalue().decode('utf-8'), file=sys.stderr)
                         continue
                 except BlockingIOError:
                     pass
@@ -407,31 +415,33 @@ class LspTestClient(LspClient):
             [self.server_path] + self.server_params,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
-            # stderr=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
             bufsize=0,
-            # bufsize=1,
         )
+
         if self.server.stdout is None:
             raise RuntimeError("Cannot read from server stdout")
         if self.server.stdin is None:
             raise RuntimeError("Cannot write to server stdin")
-        # if self.server.stderr is None:
-        #     raise RuntimeError("Cannot read from server stderr")
+        if self.server.stderr is None:
+            raise RuntimeError("Cannot read from server stderr")
 
         # Make process stdout non-blocking
         stdout_fd = self.server.stdout.fileno()
         os.set_blocking(stdout_fd, False)
-        # stderr_fd = self.server.stderr.fileno()
-        # os.set_blocking(stderr_fd, False)
+        stderr_fd = self.server.stderr.fileno()
+        os.set_blocking(stderr_fd, False)
+
+        self.process = psutil.Process(self.server.pid)
 
         self.message_stream = LspJsonStream(
             SpyIO(self.server.stdout, self.stdout_log),
-            self.timeout_s
+            self.timeout_s,
+            self.check_server
         )
         self.ostream = SpyIO(self.server.stdin, self.stdin_log)
 
-        # self.stderr_printer.start()
+        self.stderr_printer.start()
 
         initialize_id = self.send_initialize(self.initialize_params())
         self.await_response(initialize_id)
@@ -445,22 +455,32 @@ class LspTestClient(LspClient):
         self.send_exit()
 
         self.stop.set()
-        # self.stderr_printer.join()
+        self.stderr_printer.join()
 
         try:
-            self.server.wait(timeout=self.timeout_s)
+            if self.timeout_s > 0.0:
+                self.server.wait(timeout=self.timeout_s)
+            else:
+                self.server.wait()
         except subprocess.TimeoutExpired as e:
-            os.kill(self.server.pid, signal.SIGKILL)
-            raise RuntimeError(
-                f"Timed-out after {self.timeout_s} seconds while awaiting the server to terminate."
-            ) from e
+            try:
+                os.kill(self.server.pid, signal.SIGKILL)
+                raise RuntimeError(
+                    f"Timed-out after {self.timeout_s} seconds while awaiting the server to terminate."
+                ) from e
+            except ProcessLookupError:
+                pass
 
     def check_server(self) -> bool:
-        if self.server.poll():
-            raise RuntimeError(
-                f"ServerProcess crashed with status: {self.server.returncode}"
-            )
-        return True
+        if self.process.is_running():
+            if self.process.status() == psutil.STATUS_ZOMBIE:
+                raise RuntimeError(
+                    "ServerProcess has become defunct and will no longer respond"
+                )
+            return True
+        raise RuntimeError(
+            f"ServerProcess crashed with status: {self.server.returncode}"
+        )
 
     def send_message(self, message: Any) -> None:
         self.events.append(OutgoingEvent(message))
@@ -474,12 +494,12 @@ class LspTestClient(LspClient):
         self.buf.write(f"Content-Length: {len(body)}\r\n".encode("utf-8"))
         self.buf.write(b"\r\n")
         self.buf.write(body)
-        self.check_server()
         print(
             f"[{timestamp()}] Sending:\n{self.buf.getvalue().decode('utf-8')}",
             file=self.log_file
         )
         self.log_file.flush()
+        self.check_server()
         self.ostream.write(self.buf.getvalue())
         self.ostream.flush()
 

--- a/tests/server/tests/conftest.py
+++ b/tests/server/tests/conftest.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import signal
 import sys
+import time
 from pathlib import Path
 from typing import Iterator, Optional
 
@@ -16,6 +17,8 @@ def client(request: pytest.FixtureRequest) -> Iterator[LFortranLspTestClient]:
     if 'LFORTRAN_PATH' in os.environ:
         server_path = os.environ['LFORTRAN_PATH']
     if server_path is None or not os.path.exists(server_path):
+        server_path = Path(__file__).absolute().parent.parent.parent.parent / "src" / "bin" / "lfortran"
+    if server_path is None:
         server_path = shutil.which('lfortran')
     if server_path is None:
         raise RuntimeError('cannot determine location of lfortran')
@@ -23,11 +26,14 @@ def client(request: pytest.FixtureRequest) -> Iterator[LFortranLspTestClient]:
     if not (server_path.exists() and os.access(server_path, os.X_OK)):
         raise RuntimeError(f'Invalid or non-executable path to lfortran: {server_path}')
 
+    compiler_path = server_path
+
     server_log_path = f"{request.node.name}-server.log"
     client_log_path = f"{request.node.name}-client.log"
     stdout_log_path = f"{request.node.name}-stdout.log"
     stdin_log_path = f"{request.node.name}-stdin.log"
     gdb_log_path = f"{request.node.name}-gdb.log"
+    lldb_log_path = f"{request.node.name}-lldb.log"
 
     config = {
         "LFortran": {
@@ -57,7 +63,44 @@ def client(request: pytest.FixtureRequest) -> Iterator[LFortranLspTestClient]:
         }
     }
 
-    server_args = [
+    server_args = []
+
+    # FIXME: Find the correct combination of commands to get LLDB to dump crashes
+    # to a log file like GDB and uncomment the following to enable it:
+    # ---------------------------------------------------------------------------
+    # lldb_path = shutil.which('lldb')
+    lldb_path = None  #<- FIXME: When LLDB is enabled, remove this line.
+
+    gdb_path = shutil.which('gdb')
+
+    if lldb_path is not None:
+        server_args += [
+            "-q",
+            "-b",
+            "-o", "run",
+            "-o", "bt",
+            "-o", f"log enable lldb crashlog {lldb_log_path}",
+            "-o", "quit",
+            str(compiler_path),
+            "--",
+        ]
+        server_path = Path(lldb_path)
+    elif gdb_path is not None:
+        server_args += [
+            "-q", "-batch",
+            "-ex", "set logging enabled off",
+            "-ex", "set logging redirect on",
+            "-ex", "set logging debugredirect on",
+            "-ex", "set logging overwrite on",
+            "-ex", f"set logging file {gdb_log_path}",
+            "-ex", "set logging enabled on",
+            "-ex", "run",
+            "-ex", "bt",
+            "--args", str(compiler_path),
+        ]
+        server_path = Path(gdb_path)
+
+    server_args += [
         "server",
         "--parent-process-id", str(os.getpid()),
         "--log-level", config["LFortran"]["log"]["level"],
@@ -69,7 +112,7 @@ def client(request: pytest.FixtureRequest) -> Iterator[LFortranLspTestClient]:
         "--open-issue-reporter-on-error", str(config["LFortran"]["openIssueReporterOnError"]).lower(),
         "--max-number-of-problems", str(config["LFortran"]["maxNumberOfProblems"]),
         "--trace-server", config["LFortran"]["trace"]["server"],
-        "--compiler-path", str(server_path),
+        "--compiler-path", str(compiler_path),
         "--log-pretty-print", str(config["LFortran"]["log"]["prettyPrint"]).lower(),
         "--indent-size", str(config["LFortran"]["indentSize"]),
         "--max-retry-attempts", str(config["LFortran"]["retry"]["maxAttempts"]),
@@ -91,14 +134,17 @@ def client(request: pytest.FixtureRequest) -> Iterator[LFortranLspTestClient]:
             with open(log_path) as f:
                 print(f.read(), file=sys.stderr)
         else:
-            print(f"Log file does not exist: {log_path}")
+            print(f"Log file does not exist: {log_path}", file=sys.stderr)
 
     def print_logs() -> None:
         print_log(client_log_path, "Client Logs")
         print_log(stdin_log_path, "Standard Input")
         print_log(stdout_log_path, "Standard Output")
         print_log(server_log_path, "Server Logs")
-        print_log(gdb_log_path, "GNU Debugger (GDB)")
+        if lldb_path is  not None:
+            print_log(lldb_log_path, "Low-Level Debugger (LLDB)")
+        elif gdb_path is not None:
+            print_log(gdb_log_path, "GNU Debugger (GDB)")
 
     client: Optional[LFortranLspTestClient] = None
     logs_printed = False
@@ -107,7 +153,7 @@ def client(request: pytest.FixtureRequest) -> Iterator[LFortranLspTestClient]:
             server_path=server_path,
             server_params=server_args,
             workspace_path=None,
-            timeout_ms=1000,
+            timeout_ms=3000,
             config=config,
             client_log_path=client_log_path,
             stdout_log_path=stdout_log_path,
@@ -128,12 +174,19 @@ def client(request: pytest.FixtureRequest) -> Iterator[LFortranLspTestClient]:
             logs_printed = True
         raise e
     finally:
-        if client is not None and hasattr(client, 'server') \
-           and not client.server.poll():
-            print(
-                'Server did not terminate cleanly, terminating it forcefully ...',
-                file=sys.stderr
-            )
-            os.kill(client.server.pid, signal.SIGKILL)
+        try:
+            if client is not None and hasattr(client, 'server') \
+               and client.server.poll():
+                print(
+                    'Server did not terminate cleanly, terminating it forcefully ...',
+                    file=sys.stderr
+                )
+                os.kill(client.server.pid, signal.SIGINT)
+                time.sleep(1.0)
+                if not client.server.poll():
+                    os.kill(client.server.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        finally:
             if not logs_printed:
                 print_logs()


### PR DESCRIPTION
Changes:
1. BUGFIX: fixes parser expression that resulted in segfaults when the line end information for a program was unavailable
2. automatically runs tests with GDB if it is available
3. Bumps-up the timeouts because GDB makes the tests run slower
4. Locks the logger around each call to LFortranAccessor so stderr can be safely logged within LFortran without requiring the use of the Logger
5. Raises an exception if the server process remains alive but becomes defunct
6. Re-enables printing of the stderr stream from the server
7. Does a better job of buffering subprocess stdout/stderr from the test client
8. Uses the locally compiled version of LFortran if it is available
9. Does a cleaner job of shutting down the server at the end of the test if it was not shut down cleanly

Fixes the following failure: https://github.com/lfortran/lfortran/pull/6829